### PR TITLE
Added CORS support for localhost:3000

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/TeamsController.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsController.kt
@@ -2,9 +2,16 @@ package team.finder.api.teams
 
 import org.springframework.web.bind.annotation.*
 import java.util.*
+import javax.servlet.http.HttpServletResponse
+
 
 @RestController
 class TeamsController(val service: TeamsService) {
+    @ModelAttribute
+    fun setResponseHeader(response: HttpServletResponse) {
+//        this isn't ideal but it's kind of fine, it means anybody can use the API from a locally hosted webpage
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000")
+    }
 
     @GetMapping("/teams")
     fun index() : MutableIterable<Team> = service.getTeams()


### PR DESCRIPTION
So that data can be requested from the dev front-end, CORS support for the origin "http://localhost:3000" has been added. It's not ideal, as it means anybody hosting on that origin can use our API, but it's not a big deal since they could do that via our site anyway.