### PR TITLE
Remove conflicting DB configuration to allow remote DB to stand up

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,10 +1,4 @@
 server.port = 8080
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.h2.console.enabled=true
 
 spring.security.oauth2.client.registration.discord.provider=discord
 spring.security.oauth2.client.registration.discord.authorization-grant-type=authorization_code


### PR DESCRIPTION
Remote uses MySQL properties with local creds; if the h2.Driver
config field is present, it stops the DB from starting.