### PR TITLE
Allow CreateTeams to send validly-formatted Entity to DB

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/Team.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/Team.kt
@@ -1,5 +1,6 @@
 package team.finder.api.teams
 
+import team.finder.api.utils.TimestampUtils
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Table
@@ -14,13 +15,13 @@ class Team(
     // Managed by DB
     val createdAt: String,
     var updatedAt: String,
-    var deletedAt: String,
+    var deletedAt: String?,
 
     @Id val id: Long
 ) {
 
     constructor(_author: String, _description: String, _skillsetMask: Int) :
-            this(_author, _description, _skillsetMask, "", "", "", 0)
+            this(_author, _description, _skillsetMask, TimestampUtils.getCurrentTimeStamp(), TimestampUtils.getCurrentTimeStamp(), null, 0)
 
     constructor() : this("", "", 1)
 

--- a/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
@@ -3,6 +3,7 @@ package team.finder.api.teams
 import org.springframework.data.domain.Pageable
 import org.springframework.data.util.Streamable
 import org.springframework.stereotype.Service
+import team.finder.api.utils.TimestampUtils
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -40,7 +41,7 @@ class TeamsService(val repository: TeamsRepository) {
         }
 
         val team = maybeTeam.get()
-        team.deletedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        team.deletedAt = TimestampUtils.getCurrentTimeStamp()
 
         return repository.save(team)
     }

--- a/app/src/main/kotlin/team/finder/api/utils/TimestampUtils.kt
+++ b/app/src/main/kotlin/team/finder/api/utils/TimestampUtils.kt
@@ -1,0 +1,10 @@
+package team.finder.api.utils
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class TimestampUtils {
+    companion object {
+        fun getCurrentTimeStamp(): String = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+    }
+}


### PR DESCRIPTION
Correctly(ish) enforce DB schema concerns around TIMESTAMP formatting