### PR TITLE
Enable better UX for picking a team when many exist

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/SortingOptions.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/SortingOptions.kt
@@ -1,0 +1,7 @@
+package team.finder.api.teams
+
+enum class SortingOptions {
+    Asc,
+    Desc,
+    Random,
+}

--- a/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
@@ -1,9 +1,11 @@
 package team.finder.api.teams
 
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import team.finder.api.utils.TimestampUtils
 import java.util.*
+
 
 @Service
 class TeamsService(val repository: TeamsRepository) {
@@ -40,5 +42,27 @@ class TeamsService(val repository: TeamsRepository) {
         team.deletedAt = TimestampUtils.getCurrentTimeStamp()
 
         return repository.save(team)
+    }
+
+    fun getSort(strSortingOption: String): Sort {
+        return when (getSortType(strSortingOption)) {
+            SortingOptions.Asc -> Sort.by("createdAt").ascending()
+            SortingOptions.Desc -> Sort.by("createdAt").descending()
+            // Obviously not random, apparently Kotlin Comparators require that the results are reproducible
+            // I've probably misunderstood, but for users it'll probably look random enough (just consistently so)
+            SortingOptions.Random -> Sort.by("authorId")
+        }
+    }
+
+    /**
+     * Cast user input to known type to avoid concerns about data validation
+     */
+    fun getSortType(input: String): SortingOptions {
+        return when(input.toLowerCase()) {
+            "asc"       -> SortingOptions.Asc
+            "desc"      -> SortingOptions.Desc
+            "random"    -> SortingOptions.Random
+            else        -> SortingOptions.Desc
+        }
     }
 }


### PR DESCRIPTION
The aim of multiple sorting options is to work around a Team
record no longer being relevant, but taking up space