### PR TITLE
Fix column names for what turns out to be a native query

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
@@ -46,11 +46,11 @@ class TeamsService(val repository: TeamsRepository) {
 
     fun getSort(strSortingOption: String): Sort {
         return when (getSortType(strSortingOption)) {
-            SortingOptions.Asc -> Sort.by("createdAt").ascending()
-            SortingOptions.Desc -> Sort.by("createdAt").descending()
+            SortingOptions.Asc -> Sort.by("updated_at").ascending()
+            SortingOptions.Desc -> Sort.by("updated_at").descending()
             // Obviously not random, apparently Kotlin Comparators require that the results are reproducible
             // I've probably misunderstood, but for users it'll probably look random enough (just consistently so)
-            SortingOptions.Random -> Sort.by("authorId")
+            SortingOptions.Random -> Sort.by("author_id")
         }
     }
 


### PR DESCRIPTION
Swapping from `created` to `updated` was intentional, as a way to give edited teams (i.e. a team that has filled one of several roles) more visibility due to ongoing engagement.