### PR TITLE
Horrifying check to make sure correct column name is used for query

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/TeamsController.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsController.kt
@@ -37,7 +37,8 @@ class TeamsController(val service: TeamsService) {
 
         val pageIdx = if (page > 0) page else 1
 
-        val sort: Sort = service.getSort(strSortingOption)
+        val willPerformNativeQuery: Boolean = skillsetMask?.equals(null) == false
+        val sort: Sort = service.getSort(strSortingOption, willPerformNativeQuery)
 
         // Pagination needs to be offset by -1 from expectations, but can't be set below 0
         val queryPageable: PageRequest = PageRequest.of(pageIdx - 1, pageSize, sort)

--- a/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/TeamsService.kt
@@ -44,13 +44,17 @@ class TeamsService(val repository: TeamsRepository) {
         return repository.save(team)
     }
 
-    fun getSort(strSortingOption: String): Sort {
+    fun getSort(strSortingOption: String, isNativeQuery: Boolean): Sort {
+
+        val updatedColumnName = if (isNativeQuery) "updated_at" else "updateAt"
+        val authorColumnName = if (isNativeQuery) "author_id" else "authorId"
+
         return when (getSortType(strSortingOption)) {
-            SortingOptions.Asc -> Sort.by("updated_at").ascending()
-            SortingOptions.Desc -> Sort.by("updated_at").descending()
+            SortingOptions.Asc -> Sort.by(updatedColumnName).ascending()
+            SortingOptions.Desc -> Sort.by(updatedColumnName).descending()
             // Obviously not random, apparently Kotlin Comparators require that the results are reproducible
             // I've probably misunderstood, but for users it'll probably look random enough (just consistently so)
-            SortingOptions.Random -> Sort.by("author_id")
+            SortingOptions.Random -> Sort.by(authorColumnName)
         }
     }
 


### PR DESCRIPTION
It might have been easier to update the queries/DB schema, but no way am I doing that shortly before we want to demo!