### PR TITLE
Pass Discord account ID as string to avoid JSON precision issues

### DIFF
--- a/app/src/main/kotlin/team/finder/api/teams/Team.kt
+++ b/app/src/main/kotlin/team/finder/api/teams/Team.kt
@@ -9,7 +9,7 @@ import javax.persistence.Table
 @Table(name = "team")
 class Team(
     var author: String?,
-    var authorId: Long?,
+    var authorId: String?,
     var description: String,
     var skillsetMask: Int,
 
@@ -22,7 +22,7 @@ class Team(
 ) {
 
     constructor(_author: String?, _authorId: Long?, _description: String, _skillsetMask: Int) :
-            this(_author, _authorId, _description, _skillsetMask, TimestampUtils.getCurrentTimeStamp(), TimestampUtils.getCurrentTimeStamp(), null, 0)
+            this(_author, _authorId.toString(), _description, _skillsetMask, TimestampUtils.getCurrentTimeStamp(), TimestampUtils.getCurrentTimeStamp(), null, 0)
 
     constructor() : this("", 1, "", 1)
 


### PR DESCRIPTION
The DB still holds the ID as a BIGINT, so as long as discord IDs don't get higher than `9223372036854775808` (which is approximately 10x higher than the highest ID we've seen so far), we should be fine for now.

Just changing the internal type is the lightest touch approach for this bugfix